### PR TITLE
Add support for lodash 4.x (Found in Grunt 1.x)

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
 		var name = me.name;
 		var target = me.target;
 
-		_.each(_.rest(arguments), function (key) {
+		_.each(_.tail(arguments), function (key) {
 			_property.call(properties, key, _.find([
 				grunt.option([ name, target, key ].join(".")),
 				grunt.option([ name, key ].join(".")),


### PR DESCRIPTION
- Changed lodash `rest` usage to tail.
  - Note this still supports lodash 3.x as tail was an alias for the original rest.  Both 3.x and 4.x tail do the same thing.
